### PR TITLE
Recent GCC and Clang

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -61,3 +61,9 @@ clang-5.0:
         CONAN_CLANG_VERSIONS: "5.0"
     <<: *build-template
 
+clang-6.0:
+    image: lasote/conanclang60
+    variables:
+        CONAN_CLANG_VERSIONS: "6.0"
+    <<: *build-template
+

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -37,6 +37,12 @@ gcc-7:
         CONAN_GCC_VERSIONS: "7"
     <<: *build-template
 
+gcc-8:
+    image: lasote/conangcc8
+    variables:
+        CONAN_GCC_VERSIONS: "8"
+    <<: *build-template
+
 clang-3.9:
     image: lasote/conanclang39
     variables:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -55,3 +55,9 @@ clang-4.0:
         CONAN_CLANG_VERSIONS: "4.0"
     <<: *build-template
 
+clang-5.0:
+    image: lasote/conanclang50
+    variables:
+        CONAN_CLANG_VERSIONS: "5.0"
+    <<: *build-template
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,6 +41,9 @@ matrix:
       - <<: *linux
         env: CONAN_CLANG_VERSIONS=4.0 CONAN_DOCKER_IMAGE=lasote/conanclang40
 
+      - <<: *linux
+        env: CONAN_CLANG_VERSIONS=5.0 CONAN_DOCKER_IMAGE=lasote/conanclang50
+
       - <<: *osx
         osx_image: xcode7.3
         env: CONAN_APPLE_CLANG_VERSIONS=7.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,9 @@ matrix:
         env: CONAN_GCC_VERSIONS=7 CONAN_DOCKER_IMAGE=lasote/conangcc7
 
       - <<: *linux
+        env: CONAN_GCC_VERSIONS=8 CONAN_DOCKER_IMAGE=lasote/conangcc8
+
+      - <<: *linux
         env: CONAN_CLANG_VERSIONS=3.9 CONAN_DOCKER_IMAGE=lasote/conanclang39
 
       - <<: *linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,6 +44,9 @@ matrix:
       - <<: *linux
         env: CONAN_CLANG_VERSIONS=5.0 CONAN_DOCKER_IMAGE=lasote/conanclang50
 
+      - <<: *linux
+        env: CONAN_CLANG_VERSIONS=6.0 CONAN_DOCKER_IMAGE=lasote/conanclang60
+
       - <<: *osx
         osx_image: xcode7.3
         env: CONAN_APPLE_CLANG_VERSIONS=7.3


### PR DESCRIPTION
Adds the recent versions of GCC and Clang:

- GCC 8
- Clang 5.0
- Clang 6.0