### PR TITLE
CppUTest Build Options

### DIFF
--- a/build.py
+++ b/build.py
@@ -9,6 +9,6 @@ if __name__ == "__main__":
     builder.add_common_builds()
     # Give us a foot-hold to manually test conan package options
     for settings, options, env_vars, build_requires, reference in builder.items:
-        #options["CppUTest:coverage"] = True
+        #options["CppUTest:coverage"] = 'ON'
         pass
     builder.run()

--- a/build.py
+++ b/build.py
@@ -7,4 +7,8 @@ if __name__ == "__main__":
         stable_branch_pattern="release*",
         channel="testing")
     builder.add_common_builds()
+    # Give us a foot-hold to manually test conan package options
+    for settings, options, env_vars, build_requires, reference in builder.items:
+        #options["CppUTest:coverage"] = True
+        pass
     builder.run()

--- a/conanfile.py
+++ b/conanfile.py
@@ -14,6 +14,7 @@ class CppUTest(ConanFile):
         "shared": [True, False],
         "use_std_c_lib": [True, False],
         "use_std_cpp_lib": [True, False],
+        "detect_mem_leaks": [True, False],
         "fPIC": [True, False],
         "tests": [True, False],
         "extensions": [True, False]
@@ -22,6 +23,7 @@ class CppUTest(ConanFile):
         "shared=False",
         "use_std_c_lib=True",
         "use_std_cpp_lib=True",
+        "detect_mem_leaks=True",
         "fPIC=False",
         "tests=True",
         "extensions=True"
@@ -42,6 +44,7 @@ class CppUTest(ConanFile):
         # Translate our options to CppUTest's cmake options
         cmake.definitions["STD_C"] = self.options.use_std_c_lib
         cmake.definitions["STD_CPP"] = self.options.use_std_cpp_lib
+        cmake.definitions["MEMORY_LEAK_DETECTION"] = self.options.detect_mem_leaks
         cmake.definitions["TESTS"] = self.options.tests
         cmake.configure(source_dir=os.path.join(self.source_folder, self.source_dir))
         return cmake

--- a/conanfile.py
+++ b/conanfile.py
@@ -13,26 +13,26 @@ class CppUTest(ConanFile):
     options = {
         "shared": [True, False],
         "fPIC": [True, False],
-        "use_std_c_lib": [True, False],
-        "use_std_cpp_lib": [True, False],
-        "use_cpp11": [True, False],
-        "detect_mem_leaks": [True, False],
-        "extensions": [True, False],
-        "longlong": [True, False],
-        "coverage": [True, False],
-        "tests": [True, False]
+        "use_std_c_lib": ["ON", "OFF"],
+        "use_std_cpp_lib": ["ON", "OFF"],
+        "use_cpp11": ["ON", "OFF"],
+        "detect_mem_leaks": ["ON", "OFF"],
+        "extensions": ["ON", "OFF"],
+        "longlong": ["ON", "OFF"],
+        "coverage": ["ON", "OFF"],
+        "tests": ["ON", "OFF"]
     }
     default_options = (
         "shared=False",
         "fPIC=False",
-        "use_std_c_lib=True",
-        "use_std_cpp_lib=True",
-        "use_cpp11=True",
-        "detect_mem_leaks=True",
-        "extensions=True",
-        "longlong=True",
-        "coverage=False",
-        "tests=True"
+        "use_std_c_lib=ON",
+        "use_std_cpp_lib=ON",
+        "use_cpp11=ON",
+        "detect_mem_leaks=ON",
+        "extensions=ON",
+        "longlong=ON",
+        "coverage=OFF",
+        "tests=ON"
     )
     scm = {
         "type": "git",
@@ -56,6 +56,7 @@ class CppUTest(ConanFile):
         cmake.definitions["LONGLONG"] = self.options.longlong
         cmake.definitions["COVERAGE"] = self.options.coverage
         cmake.definitions["TESTS"] = self.options.tests
+        #self.output.info("definitions={}".format(cmake.definitions))
         cmake.configure(source_dir=os.path.join(self.source_folder, self.source_dir))
         return cmake
 

--- a/conanfile.py
+++ b/conanfile.py
@@ -17,6 +17,7 @@ class CppUTest(ConanFile):
         "use_std_cpp_lib": [True, False],
         "detect_mem_leaks": [True, False],
         "extensions": [True, False],
+        "longlong": [True, False],
         "tests": [True, False]
     }
     default_options = (
@@ -26,6 +27,7 @@ class CppUTest(ConanFile):
         "use_std_cpp_lib=True",
         "detect_mem_leaks=True",
         "extensions=True",
+        "longlong=True",
         "tests=True"
     )
     scm = {
@@ -46,6 +48,7 @@ class CppUTest(ConanFile):
         cmake.definitions["STD_CPP"] = self.options.use_std_cpp_lib
         cmake.definitions["MEMORY_LEAK_DETECTION"] = self.options.detect_mem_leaks
         cmake.definitions["EXTENSIONS"] = self.options.extensions
+        cmake.definitions["LONGLONG"] = self.options.longlong
         cmake.definitions["TESTS"] = self.options.tests
         cmake.configure(source_dir=os.path.join(self.source_folder, self.source_dir))
         return cmake

--- a/conanfile.py
+++ b/conanfile.py
@@ -18,6 +18,7 @@ class CppUTest(ConanFile):
         "detect_mem_leaks": [True, False],
         "extensions": [True, False],
         "longlong": [True, False],
+        "coverage": [True, False],
         "tests": [True, False]
     }
     default_options = (
@@ -28,6 +29,7 @@ class CppUTest(ConanFile):
         "detect_mem_leaks=True",
         "extensions=True",
         "longlong=True",
+        "coverage=False",
         "tests=True"
     )
     scm = {
@@ -49,6 +51,7 @@ class CppUTest(ConanFile):
         cmake.definitions["MEMORY_LEAK_DETECTION"] = self.options.detect_mem_leaks
         cmake.definitions["EXTENSIONS"] = self.options.extensions
         cmake.definitions["LONGLONG"] = self.options.longlong
+        cmake.definitions["COVERAGE"] = self.options.coverage
         cmake.definitions["TESTS"] = self.options.tests
         cmake.configure(source_dir=os.path.join(self.source_folder, self.source_dir))
         return cmake

--- a/conanfile.py
+++ b/conanfile.py
@@ -12,12 +12,14 @@ class CppUTest(ConanFile):
     source_dir = "{name}-{version}".format(name=name, version=version)
     options = {
         "shared": [True, False],
+        "use_std_c_lib": [True, False],
         "fPIC": [True, False],
         "tests": [True, False],
         "extensions": [True, False]
     }
     default_options = (
         "shared=False",
+        "use_std_c_lib=True",
         "fPIC=False",
         "tests=True",
         "extensions=True"
@@ -35,7 +37,8 @@ class CppUTest(ConanFile):
         cmake = CMake(self, set_cmake_flags=True)
         if os.environ.get('VERBOSE') == '1':
             cmake.verbose = True
-        # Translate our test-enabling option to CppUTest's cmake option
+        # Translate our options to CppUTest's cmake options
+        cmake.definitions["STD_C"] = self.options.use_std_c_lib
         cmake.definitions["TESTS"] = self.options.tests
         cmake.configure(source_dir=os.path.join(self.source_folder, self.source_dir))
         return cmake

--- a/conanfile.py
+++ b/conanfile.py
@@ -12,21 +12,21 @@ class CppUTest(ConanFile):
     source_dir = "{name}-{version}".format(name=name, version=version)
     options = {
         "shared": [True, False],
+        "fPIC": [True, False],
         "use_std_c_lib": [True, False],
         "use_std_cpp_lib": [True, False],
         "detect_mem_leaks": [True, False],
-        "fPIC": [True, False],
-        "tests": [True, False],
-        "extensions": [True, False]
+        "extensions": [True, False],
+        "tests": [True, False]
     }
     default_options = (
         "shared=False",
+        "fPIC=False",
         "use_std_c_lib=True",
         "use_std_cpp_lib=True",
         "detect_mem_leaks=True",
-        "fPIC=False",
-        "tests=True",
-        "extensions=True"
+        "extensions=True",
+        "tests=True"
     )
     scm = {
         "type": "git",
@@ -45,6 +45,7 @@ class CppUTest(ConanFile):
         cmake.definitions["STD_C"] = self.options.use_std_c_lib
         cmake.definitions["STD_CPP"] = self.options.use_std_cpp_lib
         cmake.definitions["MEMORY_LEAK_DETECTION"] = self.options.detect_mem_leaks
+        cmake.definitions["EXTENSIONS"] = self.options.extensions
         cmake.definitions["TESTS"] = self.options.tests
         cmake.configure(source_dir=os.path.join(self.source_folder, self.source_dir))
         return cmake

--- a/conanfile.py
+++ b/conanfile.py
@@ -15,6 +15,7 @@ class CppUTest(ConanFile):
         "fPIC": [True, False],
         "use_std_c_lib": [True, False],
         "use_std_cpp_lib": [True, False],
+        "use_cpp11": [True, False],
         "detect_mem_leaks": [True, False],
         "extensions": [True, False],
         "longlong": [True, False],
@@ -26,6 +27,7 @@ class CppUTest(ConanFile):
         "fPIC=False",
         "use_std_c_lib=True",
         "use_std_cpp_lib=True",
+        "use_cpp11=True",
         "detect_mem_leaks=True",
         "extensions=True",
         "longlong=True",
@@ -48,6 +50,7 @@ class CppUTest(ConanFile):
         # Translate our options to CppUTest's cmake options
         cmake.definitions["STD_C"] = self.options.use_std_c_lib
         cmake.definitions["STD_CPP"] = self.options.use_std_cpp_lib
+        cmake.definitions["C++11"] = self.options.use_cpp11
         cmake.definitions["MEMORY_LEAK_DETECTION"] = self.options.detect_mem_leaks
         cmake.definitions["EXTENSIONS"] = self.options.extensions
         cmake.definitions["LONGLONG"] = self.options.longlong

--- a/conanfile.py
+++ b/conanfile.py
@@ -13,6 +13,7 @@ class CppUTest(ConanFile):
     options = {
         "shared": [True, False],
         "use_std_c_lib": [True, False],
+        "use_std_cpp_lib": [True, False],
         "fPIC": [True, False],
         "tests": [True, False],
         "extensions": [True, False]
@@ -20,6 +21,7 @@ class CppUTest(ConanFile):
     default_options = (
         "shared=False",
         "use_std_c_lib=True",
+        "use_std_cpp_lib=True",
         "fPIC=False",
         "tests=True",
         "extensions=True"
@@ -39,6 +41,7 @@ class CppUTest(ConanFile):
             cmake.verbose = True
         # Translate our options to CppUTest's cmake options
         cmake.definitions["STD_C"] = self.options.use_std_c_lib
+        cmake.definitions["STD_CPP"] = self.options.use_std_cpp_lib
         cmake.definitions["TESTS"] = self.options.tests
         cmake.configure(source_dir=os.path.join(self.source_folder, self.source_dir))
         return cmake

--- a/conanfile.py
+++ b/conanfile.py
@@ -12,14 +12,12 @@ class CppUTest(ConanFile):
     source_dir = "{name}-{version}".format(name=name, version=version)
     options = {
         "shared": [True, False],
-        "include_pdbs": [True, False],
         "fPIC": [True, False],
         "tests": [True, False],
         "extensions": [True, False]
     }
     default_options = (
         "shared=False",
-        "include_pdbs=False",
         "fPIC=False",
         "tests=True",
         "extensions=True"

--- a/conanfile.py
+++ b/conanfile.py
@@ -13,6 +13,7 @@ class CppUTest(ConanFile):
     options = {
         "shared": [True, False],
         "fPIC": [True, False],
+        "verbose": [True, False],
         "use_std_c_lib": ["ON", "OFF"],
         "use_std_cpp_lib": ["ON", "OFF"],
         "use_cpp11": ["ON", "OFF"],
@@ -25,6 +26,7 @@ class CppUTest(ConanFile):
     default_options = (
         "shared=False",
         "fPIC=False",
+        "verbose=False",
         "use_std_c_lib=ON",
         "use_std_cpp_lib=ON",
         "use_cpp11=ON",
@@ -45,8 +47,7 @@ class CppUTest(ConanFile):
 
     def my_cmake(self):
         cmake = CMake(self, set_cmake_flags=True)
-        if os.environ.get('VERBOSE') == '1':
-            cmake.verbose = True
+        cmake.verbose = self.options.verbose
         # Translate our options to CppUTest's cmake options
         cmake.definitions["STD_C"] = self.options.use_std_c_lib
         cmake.definitions["STD_CPP"] = self.options.use_std_cpp_lib

--- a/test_package/conanfile.py
+++ b/test_package/conanfile.py
@@ -5,7 +5,6 @@ from conans import ConanFile, CMake, tools
 
 class CpputestTestConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
-    requires = "CppUTest/master@bschober/testing"
     generators = "cmake"
 
     def build(self):

--- a/test_package/conanfile.py
+++ b/test_package/conanfile.py
@@ -3,7 +3,7 @@ import os
 from conans import ConanFile, CMake, tools
 
 
-class CpputestTestConan(ConanFile):
+class CppUTestTestConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
     generators = "cmake"
 
@@ -11,8 +11,7 @@ class CpputestTestConan(ConanFile):
         cmake = CMake(self)
         # Current dir is "test_package/build/<build_id>" and CMakeLists.txt is
         # in "test_package"
-        if os.environ.get('VERBOSE') == '1':
-            cmake.verbose = True
+        cmake.verbose = self.options.verbose
         cmake.configure()
         cmake.build()
 

--- a/test_package/conanfile.py
+++ b/test_package/conanfile.py
@@ -11,7 +11,6 @@ class CppUTestTestConan(ConanFile):
         cmake = CMake(self)
         # Current dir is "test_package/build/<build_id>" and CMakeLists.txt is
         # in "test_package"
-        cmake.verbose = self.options.verbose
         cmake.configure()
         cmake.build()
 

--- a/test_package/example.cpp
+++ b/test_package/example.cpp
@@ -1,7 +1,6 @@
 #include <CppUTest/TestHarness.h>
 #include <CppUTest/TestRegistry.h>
 #include <CppUTest/CommandLineTestRunner.h>
-#include <CppUTestExt/MockSupportPlugin.h>
 
 TEST_GROUP(FirstTestGroup)
 {
@@ -14,9 +13,6 @@ TEST(FirstTestGroup, FirstTest)
 
 int main(int argc, const char** argv)
 {
-    MockSupportPlugin mockPlugin;
-    TestRegistry::getCurrentRegistry()->installPlugin(&mockPlugin);
-
     CommandLineTestRunner runner(argc, argv, TestRegistry::getCurrentRegistry());
     return runner.runAllTestsMain();
 }


### PR DESCRIPTION
Expose most of the CppUTest CMake build options to Conan package. Basically everything is defaulted on on enabled by default, except for test coverage.

Does this look reasonable, @offa?