### PR TITLE
Gitlab CI Clang7 image fix.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -68,7 +68,7 @@ clang-6.0:
     <<: *build-template
 
 clang-7:
-    image: conanio/conanclang7
+    image: conanio/clang7
     variables:
         CONAN_CLANG_VERSIONS: "7.0"
     <<: *build-template


### PR DESCRIPTION
Typo in the gitlab ci clang 7 image fixed.